### PR TITLE
Enable roundtrip serialization of namespaced keywords, java.util.UUID

### DIFF
--- a/src/clj_kryo/core.clj
+++ b/src/clj_kryo/core.clj
@@ -39,7 +39,7 @@
 (defn- make-clojure-keyword-serializer []
   (proxy [Serializer] []
     (write [kryo ^Output output object]
-      (.writeString output (name object)))
+      (.writeString output (str (.-sym object))))
     (read [kryo ^Input input klass]
       (clojure.lang.Keyword/intern (.readString input)))))
 

--- a/test/clj_kryo/test/core.clj
+++ b/test/clj_kryo/test/core.clj
@@ -25,6 +25,7 @@
   (is (= "abc" (kryo-round-trip "abc")))
   (is (= 'abc (kryo-round-trip 'abc)))
   (is (= :abc (kryo-round-trip :abc)))
+  (is (= :abc/def (kryo-round-trip :abc/def)))
   (is (= #uuid "2ee8cfbc-44e3-4452-b638-f099a6d3319e"
          (kryo-round-trip #uuid "2ee8cfbc-44e3-4452-b638-f099a6d3319e")))
   (is (= ["foo"] (kryo-round-trip ["foo"])))


### PR DESCRIPTION
This pull request enables correct roundtripping of:

1) Namespaced keywords such as :abc/def
2) java.util.UUID

Fixes:
https://github.com/runa-labs/clj-kryo/issues/2
https://github.com/runa-labs/clj-kryo/issues/3
