### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.runa/clj-kryo "1.3.0"
+(defproject org.clojars.runa/clj-kryo "1.4.0"
   :description "Clojure library for the Kryo serialization API."
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [com.esotericsoftware.kryo/kryo "2.21"]]


### PR DESCRIPTION
This commit bumps the (minor) version to 1.4.0, in order to make the
UUID and namespaced keyword serializers publicly addressable without
having to refer to a SHA.
